### PR TITLE
fix: remove private.key from built image

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -39,8 +39,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-      - name: Create GitHub app private key file
-        run: echo '${{ secrets.TEST_APP_PRIVATE_KEY }}' > private.key
       - name: Build and export to Docker
         uses: docker/build-push-action@v5
         with:
@@ -49,12 +47,16 @@ jobs:
           tags: test-build
       - name: Test whether we successfully get an app installation token
         run: |
+          echo "$TEST_APP_PRIVATE_KEY" > private.key
           output=$(docker run --rm -v "$PWD/private.key:/private.key" test-build $APP_ID $APP_INSTALLATION_ID '/private.key')
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "$output"
             exit $exit_code
           fi
+          rm private.key
+        env:
+          TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
       - name: Compute Docker tags to push to
         id: meta
         if: github.ref == 'refs/heads/main'
@@ -73,4 +75,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-            


### PR DESCRIPTION
The built image currently contains the test GitHub App private key

```console
$ docker run --rm --entrypoint=/bin/busybox ghcr.io/mshekow/github-app-installation-token:2024.01.31 ls /app/private.key
/app/private.key
```

This change ensures it is created during the test and removed after.

The current private key should be rotated after merging.