### PR TITLE
Run the published `app` image as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
 USER $USERNAME
 
 FROM build as app
+USER node
 ENTRYPOINT ["node", "index.js"]
 CMD ["--help"]


### PR DESCRIPTION
Switch to the unprivileged `node` user (UID 1000) the base image already provides to not run as root. 

