### PR TITLE
Add CalVer changelog generation and release automation

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -9,12 +9,18 @@ on:
     paths-ignore:
       - 'README.md'
       - 'renovate.json'
+      # The changelog step below commits CHANGELOG.md back to main; ignore it
+      # (together with "[skip ci]") so that commit does not re-trigger this job.
+      - 'CHANGELOG.md'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'README.md'
       - 'renovate.json'
+      # The changelog step below commits CHANGELOG.md back to main; ignore it
+      # (together with "[skip ci]") so that commit does not re-trigger this job.
+      - 'CHANGELOG.md'
 
 jobs:
   build-test-push:
@@ -23,11 +29,13 @@ jobs:
       APP_ID: 322780
       APP_INSTALLATION_ID: 36777409
     permissions:
-      contents: read
+      contents: write  # push the changelog commit + release tag, and create the GitHub release
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0  # git-cliff needs full history to build the changelog
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v4
         with:
@@ -56,6 +64,63 @@ jobs:
             exit $exit_code
           fi
           rm private.key
+      # Generate the changelog, create the release tag, and publish a GitHub
+      # release BEFORE the image is built/pushed, so the release notes for the
+      # new version are already resolvable by downstream tools (e.g. Renovate)
+      # the moment the matching image tag appears.
+      - name: Generate changelog and release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_CLIFF: orhun/git-cliff:2.12.0
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # The merge range = commits introduced by this push. Computing the new
+          # section from a commit range (not from tags) means this works on the
+          # very first run with no pre-existing tags, and never rewrites history
+          # already captured in the committed CHANGELOG.md.
+          before="$BEFORE_SHA"
+          if ! git rev-parse -q --verify "${before}^{commit}" >/dev/null 2>&1; then
+            before="$(git rev-parse HEAD~1)"  # fallback (e.g. all-zero before SHA)
+          fi
+          range="${before}..${AFTER_SHA}"
+
+          # CalVer tag matching the image's {{date 'YYYY.MM.DD'}}, with a .N
+          # suffix if there is already a release for today (keeps each section
+          # and tag unique on busy days).
+          base="$(date -u +%Y.%m.%d)"; tag="$base"; n=1
+          while git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; do
+            n=$((n + 1)); tag="$base.$n"
+          done
+
+          run_cliff() { docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/w" -w /w "$GIT_CLIFF" "$@"; }
+
+          # Prepend this release's section to CHANGELOG.md.
+          run_cliff --tag "$tag" --prepend CHANGELOG.md "$range"
+
+          # Nothing changelog-worthy (only non-conventional commits)? Still let the
+          # image publish, but skip the tag/commit/release for an empty section.
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No changelog-worthy commits in $range; skipping release $tag."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): release $tag [skip ci]"
+          git tag "$tag"
+          git push origin "HEAD:$BRANCH"
+          git push origin "$tag"
+
+          # Publish a GitHub release carrying just this version's notes.
+          run_cliff --tag "$tag" --strip header "$range" > "$RUNNER_TEMP/notes.md"
+          gh release create "$tag" --title "$tag" --notes-file "$RUNNER_TEMP/notes.md"
+
       - name: Compute Docker tags to push to
         id: meta
         if: github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,640 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+This project uses [CalVer](https://calver.org/) (`YYYY.MM.DD`) to match the
+published Docker image tags. The changelog is generated with
+[git-cliff](https://git-cliff.org) from [Conventional Commits](https://www.conventionalcommits.org).
+
+## [2026.06.25](https://github.com/MShekow/github-app-installation-token/compare/2026.06.19...2026.06.25) - 2026-06-25
+
+### 📦 Dependencies
+
+- Update node.js to v24.18.0 (#113)
+
+## [2026.06.19](https://github.com/MShekow/github-app-installation-token/compare/2026.06.18...2026.06.19) - 2026-06-19
+
+### 📦 Dependencies
+
+- Update actions/checkout action to v7 (#112)
+
+## [2026.06.18](https://github.com/MShekow/github-app-installation-token/compare/2026.06.03...2026.06.18) - 2026-06-18
+
+### 📦 Dependencies
+
+- Update node.js to v24.17.0 (#111)
+
+## [2026.06.03](https://github.com/MShekow/github-app-installation-token/compare/2026.05.22...2026.06.03) - 2026-06-03
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to df4cb1c (#110)
+
+## [2026.05.22](https://github.com/MShekow/github-app-installation-token/compare/2026.04.16...2026.05.22) - 2026-05-22
+
+### 📦 Dependencies
+
+- Update node.js to v24.16.0 (#108)
+
+## [2026.04.16](https://github.com/MShekow/github-app-installation-token/compare/2026.03.06...2026.04.16) - 2026-04-16
+
+### 📦 Dependencies
+
+- Update node.js to v24.15.0 (#107)
+
+## [2026.03.06](https://github.com/MShekow/github-app-installation-token/compare/2026.03.05...2026.03.06) - 2026-03-06
+
+### 📦 Dependencies
+
+- Update docker/build-push-action action to v7 (#106)
+
+## [2026.03.05](https://github.com/MShekow/github-app-installation-token/compare/2026.03.04...2026.03.05) - 2026-03-05
+
+### 📦 Dependencies
+
+- Update docker/metadata-action action to v6 (#105)
+- Update docker/setup-buildx-action action to v4 (#104)
+
+## [2026.03.04](https://github.com/MShekow/github-app-installation-token/compare/2026.02.13...2026.03.04) - 2026-03-04
+
+### 📦 Dependencies
+
+- Update docker/setup-qemu-action action to v4 (#103)
+- Update node.js to v24.14.0 (#101)
+- Update docker/login-action action to v4 (#102)
+
+## [2026.02.13](https://github.com/MShekow/github-app-installation-token/compare/2026.01.15...2026.02.13) - 2026-02-13
+
+### 📦 Dependencies
+
+- Update node.js to v24.13.1 (#100)
+- Update actions/checkout digest to de0fac2 (#99)
+
+## [2026.01.15](https://github.com/MShekow/github-app-installation-token/compare/2025.12.02...2026.01.15) - 2026-01-15
+
+### 📦 Dependencies
+
+- Update node.js to v24.13.0 (#97)
+
+## [2025.12.02](https://github.com/MShekow/github-app-installation-token/compare/2025.11.20...2025.12.02) - 2025-12-02
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 8e8c483 (#96)
+
+## [2025.11.20](https://github.com/MShekow/github-app-installation-token/compare/2025.11.18...2025.11.20) - 2025-11-20
+
+### 📦 Dependencies
+
+- Update actions/checkout action to v6 (#95)
+
+## [2025.11.18](https://github.com/MShekow/github-app-installation-token/compare/2025.11.13...2025.11.18) - 2025-11-18
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 93cb6ef (#94)
+
+## [2025.11.13](https://github.com/MShekow/github-app-installation-token/compare/2025.10.31...2025.11.13) - 2025-11-13
+
+### 📦 Dependencies
+
+- Update node.js to v24.11.1 (#93)
+
+## [2025.10.31](https://github.com/MShekow/github-app-installation-token/compare/2025.10.29...2025.10.31) - 2025-10-31
+
+### 📦 Dependencies
+
+- Update dependency octokit to v5.0.5 (#92)
+
+## [2025.10.29](https://github.com/MShekow/github-app-installation-token/compare/2025.10.28...2025.10.29) - 2025-10-29
+
+### 📦 Dependencies
+
+- Update node.js to v24.11.0 (#91)
+
+## [2025.10.28](https://github.com/MShekow/github-app-installation-token/compare/2025.10.22...2025.10.28) - 2025-10-28
+
+### 📦 Dependencies
+
+- Update node.js to v24 (#90)
+
+## [2025.10.22](https://github.com/MShekow/github-app-installation-token/compare/2025.10.18...2025.10.22) - 2025-10-22
+
+### 📦 Dependencies
+
+- Update node.js to v22.21.0 (#89)
+
+## [2025.10.18](https://github.com/MShekow/github-app-installation-token/compare/2025.09.24...2025.10.18) - 2025-10-18
+
+### 📦 Dependencies
+
+- Update dependency octokit to v5.0.4 (#88)
+
+## [2025.09.24](https://github.com/MShekow/github-app-installation-token/compare/2025.08.31...2025.09.24) - 2025-09-24
+
+### 📦 Dependencies
+
+- Update node.js to v22.20.0 (#87)
+
+## [2025.08.31](https://github.com/MShekow/github-app-installation-token/compare/2025.08.11...2025.08.31) - 2025-08-31
+
+### 📦 Dependencies
+
+- Update node.js to v22.19.0 (#86)
+
+## [2025.08.11](https://github.com/MShekow/github-app-installation-token/compare/2025.08.04...2025.08.11) - 2025-08-11
+
+### 📦 Dependencies
+
+- Update actions/checkout action to v5 (#85)
+- Update actions/checkout digest to 08eba0b (#84)
+
+## [2025.08.04](https://github.com/MShekow/github-app-installation-token/compare/2025.07.17...2025.08.04) - 2025-08-04
+
+### 📦 Dependencies
+
+- Update node.js to v22.18.0 (#83)
+
+## [2025.07.17](https://github.com/MShekow/github-app-installation-token/compare/2025.05.28...2025.07.17) - 2025-07-17
+
+### 📦 Dependencies
+
+- Update node.js to v22.17.1 (#82)
+
+## [2025.05.28](https://github.com/MShekow/github-app-installation-token/compare/2025.05.27...2025.05.28) - 2025-05-28
+
+### 📦 Dependencies
+
+- Update dependency octokit to v5.0.3 (#81)
+
+## [2025.05.27](https://github.com/MShekow/github-app-installation-token/compare/2025.05.22...2025.05.27) - 2025-05-27
+
+### 📦 Dependencies
+
+- Update dependency yargs to v18 (#80)
+
+## [2025.05.22](https://github.com/MShekow/github-app-installation-token/compare/2025.05.21...2025.05.22) - 2025-05-22
+
+### 📦 Dependencies
+
+- Update node.js to v22.16.0 (#79)
+
+## [2025.05.21](https://github.com/MShekow/github-app-installation-token/compare/2025.05.20...2025.05.21) - 2025-05-21
+
+### 📦 Dependencies
+
+- Update dependency octokit to v5 (#77)
+
+## [2025.05.20](https://github.com/MShekow/github-app-installation-token/compare/2025.05.15...2025.05.20) - 2025-05-20
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.1.4 (#78)
+
+## [2025.05.15](https://github.com/MShekow/github-app-installation-token/compare/2025.04.23...2025.05.15) - 2025-05-15
+
+### 📦 Dependencies
+
+- Update node.js to v22.15.1 (#76)
+
+## [2025.04.23](https://github.com/MShekow/github-app-installation-token/compare/2025.04.10...2025.04.23) - 2025-04-23
+
+### 📦 Dependencies
+
+- Update node.js to v22.15.0 (#75)
+
+## [2025.04.10](https://github.com/MShekow/github-app-installation-token/compare/2025.02.15...2025.04.10) - 2025-04-10
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.1.3 (#74)
+
+## [2025.02.15](https://github.com/MShekow/github-app-installation-token/compare/2025.02.14...2025.02.15) - 2025-02-15
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.1.2 (#73)
+
+## [2025.02.14](https://github.com/MShekow/github-app-installation-token/compare/2025.02.07...2025.02.14) - 2025-02-14
+
+### 📦 Dependencies
+
+- Update node.js to v22.14.0 (#72)
+
+## [2025.02.07](https://github.com/MShekow/github-app-installation-token/compare/2025.01.09...2025.02.07) - 2025-02-07
+
+### 📦 Dependencies
+
+- Update node.js to v22.13.1 (#70)
+- Update dependency octokit to v4.1.1 (#71)
+
+## [2025.01.09](https://github.com/MShekow/github-app-installation-token/compare/2025.01.08...2025.01.09) - 2025-01-09
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.1.0 (#69)
+
+## [2025.01.08](https://github.com/MShekow/github-app-installation-token/compare/2024.12.30...2025.01.08) - 2025-01-08
+
+### 📦 Dependencies
+
+- Update node.js to v22.13.0 (#68)
+
+## [2024.12.30](https://github.com/MShekow/github-app-installation-token/compare/2024.12.29...2024.12.30) - 2024-12-30
+
+### 📦 Dependencies
+
+- Update node.js to v22.12.0 (#66)
+
+## [2024.12.29](https://github.com/MShekow/github-app-installation-token/compare/2024.10.30...2024.12.29) - 2024-12-29
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.0.3 (#67)
+
+## [2024.10.30](https://github.com/MShekow/github-app-installation-token/compare/2024.10.29...2024.10.30) - 2024-10-30
+
+### 📦 Dependencies
+
+- Update node.js to v22.11.0
+
+## [2024.10.29](https://github.com/MShekow/github-app-installation-token/compare/2024.10.23...2024.10.29) - 2024-10-29
+
+### 📦 Dependencies
+
+- Update node.js to v22
+
+## [2024.10.23](https://github.com/MShekow/github-app-installation-token/compare/2024.10.07...2024.10.23) - 2024-10-23
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 11bd719
+
+## [2024.10.07](https://github.com/MShekow/github-app-installation-token/compare/2024.06.17...2024.10.07) - 2024-10-07
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to eef6144
+
+## [2024.06.17](https://github.com/MShekow/github-app-installation-token/compare/2024.06.13...2024.06.17) - 2024-06-17
+
+### 📦 Dependencies
+
+- Update docker/build-push-action action to v6
+
+## [2024.06.13](https://github.com/MShekow/github-app-installation-token/compare/2024.05.21...2024.06.13) - 2024-06-13
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 692973e
+
+## [2024.05.21](https://github.com/MShekow/github-app-installation-token/compare/2024.05.09...2024.05.21) - 2024-05-21
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to a5ac7e5
+
+## [2024.05.09](https://github.com/MShekow/github-app-installation-token/compare/2024.05.08...2024.05.09) - 2024-05-09
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 44c2b7a
+
+## [2024.05.08](https://github.com/MShekow/github-app-installation-token/compare/2024.05.03...2024.05.08) - 2024-05-08
+
+### 🐛 Bug Fixes
+
+- Change Octokit import
+
+### 📦 Dependencies
+
+- Update dependency octokit to v4.0.2
+- Update dependency octokit to v4
+
+## [2024.05.03](https://github.com/MShekow/github-app-installation-token/compare/2024.04.25...2024.05.03) - 2024-05-03
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3.2.1
+
+## [2024.04.25](https://github.com/MShekow/github-app-installation-token/compare/2024.04.22...2024.04.25) - 2024-04-25
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 0ad4b8f
+
+## [2024.04.22](https://github.com/MShekow/github-app-installation-token/compare/2024.04.11...2024.04.22) - 2024-04-22
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 1d96c77
+
+## [2024.04.11](https://github.com/MShekow/github-app-installation-token/compare/2024.04.04...2024.04.11) - 2024-04-11
+
+### 📦 Dependencies
+
+- Update node.js to v21.7.3
+
+## [2024.04.04](https://github.com/MShekow/github-app-installation-token/compare/2024.04.03...2024.04.04) - 2024-04-04
+
+### 📦 Dependencies
+
+- Update node.js to v21.7.2
+
+## [2024.04.03](https://github.com/MShekow/github-app-installation-token/compare/2024.03.11...2024.04.03) - 2024-04-03
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3.2.0
+
+## [2024.03.11](https://github.com/MShekow/github-app-installation-token/compare/2024.03.08...2024.03.11) - 2024-03-11
+
+### 📦 Dependencies
+
+- Update node.js to v21.7.1
+
+## [2024.03.08](https://github.com/MShekow/github-app-installation-token/compare/2024.02.16...2024.03.08) - 2024-03-08
+
+### 📦 Dependencies
+
+- Update node.js to v21.7.0
+
+## [2024.02.16](https://github.com/MShekow/github-app-installation-token/compare/2024.02.07...2024.02.16) - 2024-02-16
+
+### 📦 Dependencies
+
+- Update node.js to v21.6.2
+
+## [2024.02.07](https://github.com/MShekow/github-app-installation-token/compare/2024.02.06...2024.02.07) - 2024-02-07
+
+### ⚙️ CI/CD
+
+- Ensure deletion of private key in CI workflow and locally
+
+## [2024.02.06](https://github.com/MShekow/github-app-installation-token/compare/2024.01.31...2024.02.06) - 2024-02-06
+
+### ⚙️ CI/CD
+
+- Swap docker build step with private-key step
+
+## [2024.01.31](https://github.com/MShekow/github-app-installation-token/compare/2024.01.17...2024.01.31) - 2024-01-31
+
+### 📦 Dependencies
+
+- Update node.js to v21.6.1
+
+## [2024.01.17](https://github.com/MShekow/github-app-installation-token/compare/2023.12.20...2024.01.17) - 2024-01-17
+
+### 📦 Dependencies
+
+- Update node.js to v21.6.0
+
+## [2023.12.20](https://github.com/MShekow/github-app-installation-token/compare/2023.12.06...2023.12.20) - 2023-12-20
+
+### 📦 Dependencies
+
+- Update node.js to v21.5.0
+
+## [2023.12.06](https://github.com/MShekow/github-app-installation-token/compare/2023.12.02...2023.12.06) - 2023-12-06
+
+### 📦 Dependencies
+
+- Update node.js to v21.4.0
+
+## [2023.12.02](https://github.com/MShekow/github-app-installation-token/compare/2023.11.16...2023.12.02) - 2023-12-02
+
+### 📦 Dependencies
+
+- Update node.js to v21.3.0
+
+## [2023.11.16](https://github.com/MShekow/github-app-installation-token/compare/2023.11.15...2023.11.16) - 2023-11-16
+
+### 📦 Dependencies
+
+- Update node.js to v21.2.0
+
+## [2023.11.15](https://github.com/MShekow/github-app-installation-token/compare/2023.10.26...2023.11.15) - 2023-11-15
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3.1.2
+
+## [2023.10.26](https://github.com/MShekow/github-app-installation-token/compare/2023.10.20...2023.10.26) - 2023-10-26
+
+### 📦 Dependencies
+
+- Update node.js to v21.1.0
+
+## [2023.10.20](https://github.com/MShekow/github-app-installation-token/compare/2023.10.19...2023.10.20) - 2023-10-20
+
+### 📦 Dependencies
+
+- Update node.js to v21
+
+## [2023.10.19](https://github.com/MShekow/github-app-installation-token/compare/2023.10.16...2023.10.19) - 2023-10-19
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to b4ffde6
+
+## [2023.10.16](https://github.com/MShekow/github-app-installation-token/compare/2023.09.26...2023.10.16) - 2023-10-16
+
+### 📦 Dependencies
+
+- Update node.js to v20.8.1
+
+## [2023.09.26](https://github.com/MShekow/github-app-installation-token/compare/2023.09.22...2023.09.26) - 2023-09-26
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3.1.1
+
+## [2023.09.22](https://github.com/MShekow/github-app-installation-token/compare/2023.09.20...2023.09.22) - 2023-09-22
+
+### 📦 Dependencies
+
+- Update actions/checkout digest to 8ade135
+
+## [2023.09.20](https://github.com/MShekow/github-app-installation-token/compare/2023.09.12...2023.09.20) - 2023-09-20
+
+### 📦 Dependencies
+
+- Update node.js to v20.7.0
+
+## [2023.09.12](https://github.com/MShekow/github-app-installation-token/compare/2023.09.11...2023.09.12) - 2023-09-12
+
+### 📦 Dependencies
+
+- Update docker/setup-qemu-action action to v3
+- Update docker/setup-buildx-action action to v3
+- Update docker/metadata-action action to v5
+- Update docker/login-action action to v3
+- Update docker/build-push-action action to v5
+
+## [2023.09.11](https://github.com/MShekow/github-app-installation-token/compare/2023.09.06...2023.09.11) - 2023-09-11
+
+### 📦 Dependencies
+
+- Update node.js to v20.6.1
+
+## [2023.09.06](https://github.com/MShekow/github-app-installation-token/compare/2023.09.04...2023.09.06) - 2023-09-06
+
+### 📦 Dependencies
+
+- Update node.js to v20.6.0
+
+## [2023.09.04](https://github.com/MShekow/github-app-installation-token/compare/2023.08.10...2023.09.04) - 2023-09-04
+
+### 📦 Dependencies
+
+- Update actions/checkout action to v4
+
+## [2023.08.10](https://github.com/MShekow/github-app-installation-token/compare/2023.07.26...2023.08.10) - 2023-08-10
+
+### 📦 Dependencies
+
+- Update node.js to v20.5.1
+
+## [2023.07.26](https://github.com/MShekow/github-app-installation-token/compare/2023.07.22...2023.07.26) - 2023-07-26
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3.1.0
+
+## [2023.07.22](https://github.com/MShekow/github-app-installation-token/compare/2023.07.18...2023.07.22) - 2023-07-22
+
+### 📦 Dependencies
+
+- Update node.js to v20.5.0
+
+## [2023.07.18](https://github.com/MShekow/github-app-installation-token/compare/2023.07.11...2023.07.18) - 2023-07-18
+
+### 📦 Dependencies
+
+- Bump semver from 7.5.0 to 7.5.4
+
+## [2023.07.11](https://github.com/MShekow/github-app-installation-token/compare/2023.06.21...2023.07.11) - 2023-07-11
+
+### 📦 Dependencies
+
+- Update dependency octokit to v3
+- Update node.js to v20.4.0
+
+## [2023.06.21](https://github.com/MShekow/github-app-installation-token/compare/2023.06.17...2023.06.21) - 2023-06-21
+
+### 📦 Dependencies
+
+- Update node.js to v20.3.1
+- Update dependency octokit to v2.1.0
+
+## [2023.06.17](https://github.com/MShekow/github-app-installation-token/compare/2023.06.16...2023.06.17) - 2023-06-17
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.22
+
+## [2023.06.16](https://github.com/MShekow/github-app-installation-token/compare/2023.06.10...2023.06.16) - 2023-06-16
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.21
+
+## [2023.06.10](https://github.com/MShekow/github-app-installation-token/compare/2023.05.27...2023.06.10) - 2023-06-10
+
+### 📦 Dependencies
+
+- Update node.js to v20.3.0
+
+## [2023.05.27](https://github.com/MShekow/github-app-installation-token/compare/2023.05.23...2023.05.27) - 2023-05-27
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.19
+
+## [2023.05.23](https://github.com/MShekow/github-app-installation-token/compare/2023.05.19...2023.05.23) - 2023-05-23
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.18
+
+## [2023.05.19](https://github.com/MShekow/github-app-installation-token/compare/2023.05.18...2023.05.19) - 2023-05-19
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.16
+
+### 📚 Documentation
+
+- Update README with Azure DevOps example
+
+## [2023.05.18](https://github.com/MShekow/github-app-installation-token/compare/2023.05.17...2023.05.18) - 2023-05-18
+
+### 📦 Dependencies
+
+- Update dependency octokit to v2.0.15
+
+## [2023.05.17](https://github.com/MShekow/github-app-installation-token/compare/2023.05.04...2023.05.17) - 2023-05-17
+
+### 📦 Dependencies
+
+- Update node.js to v20.2.0
+
+## [2023.05.04](https://github.com/MShekow/github-app-installation-token/compare/2023.05.03...2023.05.04) - 2023-05-04
+
+### 📦 Dependencies
+
+- Update node.js to v20.1.0
+
+## [2023.05.03](https://github.com/MShekow/github-app-installation-token/compare/2023.04.29...2023.05.03) - 2023-05-03
+
+### 📚 Documentation
+
+- Minor README tweaks
+
+## [2023.04.29](https://github.com/MShekow/github-app-installation-token/compare/2023.04.28...2023.04.29) - 2023-04-29
+
+### 🐛 Bug Fixes
+
+- VS Code devcontainer (migration to "apk")
+
+## [2023.04.28](https://github.com/MShekow/github-app-installation-token/compare/2023.04.27...2023.04.28) - 2023-04-28
+
+### 📦 Dependencies
+
+- Update dependency yargs to v17.7.2
+
+## [2023.04.27](https://github.com/MShekow/github-app-installation-token/compare/2023.04.26...2023.04.27) - 2023-04-27
+
+### 🧹 Miscellaneous
+
+- Disable Renovate Bot dependency dashboard
+
+## [2023.04.26] - 2023-04-26
+
+### 🚀 Features
+
+- Implement first working version of the script
+
+### 📦 Dependencies
+
+- Update node.js to v20
+
+### 📚 Documentation
+
+- Update README.md
+- Fix typo in README
+- Update README
+
+### ⚡ Performance
+
+- Use alpine instead of Debian base image
+
+### ⚙️ CI/CD
+
+- Add first CI-CD attempt
+
+### 🧹 Miscellaneous
+
+- Install GitHub Actions VS Code plugin into devcontainer
+
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Run `docker run --rm ghcr.io/mshekow/github-app-installation-token:latest` to ge
 
 The `ghcr.io/mshekow/github-app-installation-token` Docker image is built for Intel/AMD 64-bit and ARM 64-bit architectures. Just open a Pull Request if you need additional CPU architectures. It is automatically rebuilt whenever there are dependency updates
 
+## Changelog
+
+See [`CHANGELOG.md`](./CHANGELOG.md). Releases use [CalVer](https://calver.org/) (`YYYY.MM.DD`), matching the published Docker image tags.
+
+The changelog is generated from [Conventional Commits](https://www.conventionalcommits.org) with [git-cliff](https://git-cliff.org). On every merge to `main`, CI generates the new entry, creates the matching `YYYY.MM.DD` git tag and GitHub release, and commits the updated `CHANGELOG.md` _before_ the image is published — so the release notes for a given version are available as soon as its image tag appears. To preview the changelog locally, run `yarn changelog` (requires the [git-cliff CLI](https://git-cliff.org/docs/installation/)).
+
 ## Alternatives
 
 If you use **GitHub Actions** you can use https://github.com/jnwng/github-app-installation-token-action or https://github.com/tibdex/github-app-token.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,66 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+#
+# This project uses CalVer (YYYY.MM.DD) to match the Docker image tags produced
+# by .github/workflows/ci-cd.yaml. There is no SemVer; a "release" is the state
+# of `main` on a given day, published as ghcr.io/.../...:YYYY.MM.DD + :latest.
+# To cut a changelog entry for a release, tag the shipped commit with that same
+# date, e.g.  git tag 2026.06.28  (see the "Release process" section in README).
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented here.
+
+This project uses [CalVer](https://calver.org/) (`YYYY.MM.DD`) to match the
+published Docker image tags. The changelog is generated with
+[git-cliff](https://git-cliff.org) from [Conventional Commits](https://www.conventionalcommits.org).\n
+"""
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if commits | length == 0 %}{% else %}\
+{% set base_url = "https://github.com/" ~ remote.github.owner ~ "/" ~ remote.github.repo %}\
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]{% if previous and previous.version %}({{ base_url }}/compare/{{ previous.version }}...{{ version }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+    {% endfor %}
+{% endfor %}
+{% endif %}\
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+# Keep non-conventional commits (the early hand-written ones) out of the log
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix\\(deps\\)", group = "<!-- 2 -->📦 Dependencies" },
+    { message = "^chore\\(deps\\)", group = "<!-- 2 -->📦 Dependencies" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 5 -->🚜 Refactor" },
+    { message = "^ci", group = "<!-- 6 -->⚙️ CI/CD" },
+    { message = "^chore", group = "<!-- 7 -->🧹 Miscellaneous" },
+    { message = "^Merge", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+# CalVer tags: YYYY.MM.DD (optionally a .N suffix for multiple same-day releases)
+tag_pattern = "[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}.*"
+topo_order = false
+sort_commits = "newest"
+
+[remote.github]
+owner = "MShekow"
+repo = "github-app-installation-token"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/MShekow/github-app-installation-token",
   "author": "Marius Shekow",
   "license": "MIT",
+  "scripts": {
+    "changelog": "git-cliff -o CHANGELOG.md"
+  },
   "dependencies": {
     "octokit": "5.0.5",
     "yargs": "18.0.0"


### PR DESCRIPTION
## What

Introduces a maintained **`CHANGELOG.md`** for the project, generated from the repo's existing [Conventional Commits](https://www.conventionalcommits.org) with [git-cliff](https://git-cliff.org), and wires its generation into the **existing** `ci-cd.yaml` workflow (no new workflow file).

Releases stay on the current **CalVer** scheme (`YYYY.MM.DD`), matching the published Docker image tags.

Fixes #115 

## Why

There was no changelog, no git tags, and no GitHub releases — the only release signal was the date-tagged image. This adds human-readable release notes and, importantly, makes them **resolvable by downstream tooling (e.g. Renovate)** when a consumer bumps the image version.

## How it works

On every merge to `main`, ahead of the published image build, the workflow:

1. Generates the new changelog section for the commits in that merge and prepends it to `CHANGELOG.md`.
2. Creates the matching `YYYY.MM.DD` git tag (with a `.N` suffix if the day already has a release) and a **GitHub release** carrying that version's notes.
3. Commits the updated `CHANGELOG.md` back to `main` (`[skip ci]`, and `CHANGELOG.md` added to `paths-ignore`, so it does not re-trigger CI).

The changelog/tag/release are produced **before** the image is built and pushed, so the release notes for a version are available the moment its image tag appears.

The section computation uses the merge's commit range (not pre-existing tags), so it self-bootstraps on the first run and never rewrites the backfilled history. `CHANGELOG.md` is backfilled from existing history (one section per release date) and can be regenerated locally with `yarn changelog`.

## Changes

- `cliff.toml` — CalVer-aware git-cliff config (dependency bumps grouped separately)
- `CHANGELOG.md` — backfilled from history
- `package.json` — `changelog` script
- `README.md` — short Changelog section
- `.github/workflows/ci-cd.yaml` — `contents: write`, full-history checkout, the changelog/tag/release step ordered before the image push, and `CHANGELOG.md` in `paths-ignore`

## Note for the maintainer

The changelog step pushes a commit + tag to `main` using the default `GITHUB_TOKEN`. If `main` has branch protection that blocks direct pushes by Actions, that rule needs to allow this job (or the commit-back can be dropped in favor of tag + GitHub release only). Everything else is unchanged.

---

_This PR was generated with the help of AI, and reviewed by a Human_